### PR TITLE
Remove memory bottleneck

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -248,7 +248,7 @@ class Differ
     }
 
     /**
-     * Calculates the longest common subsequences of two strings.
+     * Calculates the longest common subsequence of two arrays.
      *
      * The method uses Hirschberg's algorithm that runs in linear space and
      *   quadratic time.


### PR DESCRIPTION
I was using PHPUnit when a test, which compared two big DOMDocument files, stopped due to the exceeding of the memory limit. I investigated the story, and found that the method which generates the diff for the failed tests is using a dynamic programming-based approach. This algorithm have a quadratic running time, and requires quadratic memory. 

If the available time-frame to run the tests is not extremely tight, the memory consumption is a stricter bottleneck.

In this pull request I replaced the old LCS method with a new one based on an algorithm called Hirschberg's algorithm, which also have a quadratic running time, but only uses linear space. The new algorithm is a bit slower (30-40%), but removes the memory bottleneck, thus makes PHPUnit suitable for comparing bigger items.
