### PR TITLE
Add ability to hide non-diff lines

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -32,11 +32,24 @@ class Differ
     private $header;
 
     /**
+     * @var bool
+     */
+    private $showNonDiffLines = true;
+
+    /**
      * @param string $header
      */
     public function __construct($header = "--- Original\n+++ New\n")
     {
         $this->header = $header;
+    }
+
+    /**
+     * @param bool $show
+     */
+    public function setShowNonDiffLines($show)
+    {
+        $this->showNonDiffLines = $show;
     }
 
     /**
@@ -97,7 +110,9 @@ class Differ
             }
 
             if ($newChunk) {
-                $buffer  .= "@@ @@\n";
+                if ($this->showNonDiffLines === true) {
+                    $buffer  .= "@@ @@\n";
+                }
                 $newChunk = false;
             }
 
@@ -105,7 +120,7 @@ class Differ
                 $buffer .= '+' . $diff[$i][0] . "\n";
             } elseif ($diff[$i][1] === 2 /* REMOVED */) {
                 $buffer .= '-' . $diff[$i][0] . "\n";
-            } else {
+            } elseif ($this->showNonDiffLines === true) {
                 $buffer .= ' ' . $diff[$i][0] . "\n";
             }
         }

--- a/src/Differ.php
+++ b/src/Differ.php
@@ -34,22 +34,15 @@ class Differ
     /**
      * @var bool
      */
-    private $showNonDiffLines = true;
+    private $showNonDiffLines;
 
     /**
      * @param string $header
      */
-    public function __construct($header = "--- Original\n+++ New\n")
+    public function __construct($header = "--- Original\n+++ New\n", $showNonDiffLines = true)
     {
         $this->header = $header;
-    }
-
-    /**
-     * @param bool $show
-     */
-    public function setShowNonDiffLines($show)
-    {
-        $this->showNonDiffLines = $show;
+        $this->showNonDiffLines = $showNonDiffLines;
     }
 
     /**

--- a/src/Differ.php
+++ b/src/Differ.php
@@ -111,7 +111,7 @@ class Differ
 
             if ($newChunk) {
                 if ($this->showNonDiffLines === true) {
-                    $buffer  .= "@@ @@\n";
+                    $buffer .= "@@ @@\n";
                 }
                 $newChunk = false;
             }


### PR DESCRIPTION
Sometimes it's desirable to only show lines that have changed, even if
it means stripping all context from the diff.