### PR TITLE
[DX] Add .editorconfig.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/tests/fixtures/.editorconfig
+++ b/tests/fixtures/.editorconfig
@@ -1,0 +1,1 @@
+root = true


### PR DESCRIPTION
Helpful as widely supported by editors.
The one in `fixtures` is to hint to editors to _not_ apply formatting as such files may contain content that is deliberately off.  