### PR TITLE
Remove dead code.

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -53,10 +53,6 @@ class Differ
         $start = isset($old[0]) ? $old[0] : 0;
         $end   = \count($diff);
 
-        if ($tmp = \array_search($end, $old)) {
-            $end = $tmp;
-        }
-
         return $this->getBuffer($diff, $old, $start, $end);
     }
 


### PR DESCRIPTION
These lines are never covered by the tests.  This makes sense because it should never be true and is probably a leftover from a refactor or bugged from the beginning.
The test if `$end`, which is the count of the diff array, is within $old (the same chunks list) makes no sense.
As count typically holds a number higher than is an index of the diff array the `$old` should never have it as value (as $old is based on the indexes of the diff array, i.e. offset 0 v.s. 1 bug).

The code was mostly like to stop the output of pending same lines in a diff. Given the unit tests (and observing when running PHPUnit) this doesn't work. I'll address this issue within another PR later on (when adding the needed changes to generate the output with line numbers).