### PR TITLE
Add setHeader method.

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -29,10 +29,17 @@ class Differ
      * @param string $header
      * @param bool   $showNonDiffLines
      */
-    public function __construct($header = "--- Original\n+++ New\n", $showNonDiffLines = true)
+    public function __construct(string $header = "--- Original\n+++ New\n", $showNonDiffLines = true)
     {
-        $this->header           = $header;
+        $this->setHeader($header);
         $this->showNonDiffLines = $showNonDiffLines;
+    }
+
+    public function setHeader(string $header): Differ
+    {
+        $this->header = $header;
+
+        return $this;
     }
 
     /**

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -410,4 +410,16 @@ EOL;
 
         $differ->diffToArray('', new \stdClass);
     }
+
+    public function testSettingFluent()
+    {
+        $diff = $this->differ->setHeader('testSettingFluent');
+        $this->assertSame($this->differ, $diff);
+
+        $reflection = new \ReflectionObject($this->differ);
+
+        $reflectionProperty = $reflection->getProperty('header');
+        $reflectionProperty->setAccessible(true);
+        $this->assertSame('testSettingFluent', $reflectionProperty->getValue($this->differ));
+    }
 }


### PR DESCRIPTION
BC break as the class is not `final`

This allows setting the header after construction. This is handy when reusing the differ object to generate multiple diffs.