### PR TITLE
Mark final and internal.

### DIFF
--- a/src/Chunk.php
+++ b/src/Chunk.php
@@ -10,7 +10,7 @@
 
 namespace SebastianBergmann\Diff;
 
-class Chunk
+final class Chunk
 {
     /**
      * @var int

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -10,7 +10,7 @@
 
 namespace SebastianBergmann\Diff;
 
-class Diff
+final class Diff
 {
     /**
      * @var string

--- a/src/Differ.php
+++ b/src/Differ.php
@@ -13,7 +13,7 @@ namespace SebastianBergmann\Diff;
 /**
  * Diff implementation.
  */
-class Differ
+final class Differ
 {
     /**
      * @var string

--- a/src/Line.php
+++ b/src/Line.php
@@ -10,7 +10,7 @@
 
 namespace SebastianBergmann\Diff;
 
-class Line
+final class Line
 {
     const ADDED     = 1;
     const REMOVED   = 2;

--- a/src/MemoryEfficientLongestCommonSubsequenceCalculator.php
+++ b/src/MemoryEfficientLongestCommonSubsequenceCalculator.php
@@ -10,7 +10,7 @@
 
 namespace SebastianBergmann\Diff;
 
-class MemoryEfficientLongestCommonSubsequenceCalculator implements LongestCommonSubsequenceCalculator
+final class MemoryEfficientLongestCommonSubsequenceCalculator implements LongestCommonSubsequenceCalculator
 {
     /**
      * Calculates the longest common subsequence of two arrays.

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -13,7 +13,7 @@ namespace SebastianBergmann\Diff;
 /**
  * Unified diff parser.
  */
-class Parser
+final class Parser
 {
     /**
      * @param string $string

--- a/src/TimeEfficientLongestCommonSubsequenceCalculator.php
+++ b/src/TimeEfficientLongestCommonSubsequenceCalculator.php
@@ -10,7 +10,7 @@
 
 namespace SebastianBergmann\Diff;
 
-class TimeEfficientLongestCommonSubsequenceCalculator implements LongestCommonSubsequenceCalculator
+final class TimeEfficientLongestCommonSubsequenceCalculator implements LongestCommonSubsequenceCalculator
 {
     /**
      * Calculates the longest common subsequence of two arrays.

--- a/tests/ChunkTest.php
+++ b/tests/ChunkTest.php
@@ -14,8 +14,10 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers SebastianBergmann\Diff\Chunk
+ *
+ * @internal
  */
-class ChunkTest extends TestCase
+final class ChunkTest extends TestCase
 {
     /**
      * @var Chunk

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -16,6 +16,8 @@ use PHPUnit\Framework\TestCase;
  * @covers SebastianBergmann\Diff\Diff
  *
  * @uses SebastianBergmann\Diff\Chunk
+ *
+ * @internal
  */
 final class DiffTest extends TestCase
 {

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -21,8 +21,10 @@ use PHPUnit\Framework\TestCase;
  * @uses SebastianBergmann\Diff\Diff
  * @uses SebastianBergmann\Diff\Line
  * @uses SebastianBergmann\Diff\Parser
+ *
+ * @internal
  */
-class DifferTest extends TestCase
+final class DifferTest extends TestCase
 {
     const REMOVED = 2;
     const ADDED   = 1;

--- a/tests/LineTest.php
+++ b/tests/LineTest.php
@@ -14,8 +14,10 @@ use PHPUnit\Framework\TestCase;
 
 /**
  * @covers SebastianBergmann\Diff\Line
+ *
+ * @interal
  */
-class LineTest extends TestCase
+final class LineTest extends TestCase
 {
     /**
      * @var Line

--- a/tests/LongestCommonSubsequenceTest.php
+++ b/tests/LongestCommonSubsequenceTest.php
@@ -12,6 +12,11 @@ namespace SebastianBergmann\Diff;
 
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
 abstract class LongestCommonSubsequenceTest extends TestCase
 {
     /**

--- a/tests/MemoryEfficientImplementationTest.php
+++ b/tests/MemoryEfficientImplementationTest.php
@@ -12,8 +12,10 @@ namespace SebastianBergmann\Diff;
 
 /**
  * @covers SebastianBergmann\Diff\MemoryEfficientLongestCommonSubsequenceCalculator
+ *
+ * @internal
  */
-class MemoryEfficientImplementationTest extends LongestCommonSubsequenceTest
+final class MemoryEfficientImplementationTest extends LongestCommonSubsequenceTest
 {
     protected function createImplementation()
     {

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -18,8 +18,10 @@ use PHPUnit\Framework\TestCase;
  * @uses SebastianBergmann\Diff\Chunk
  * @uses SebastianBergmann\Diff\Diff
  * @uses SebastianBergmann\Diff\Line
+ *
+ * @internal
  */
-class ParserTest extends TestCase
+final class ParserTest extends TestCase
 {
     /**
      * @var Parser

--- a/tests/TimeEfficientImplementationTest.php
+++ b/tests/TimeEfficientImplementationTest.php
@@ -12,8 +12,10 @@ namespace SebastianBergmann\Diff;
 
 /**
  * @covers SebastianBergmann\Diff\TimeEfficientLongestCommonSubsequenceCalculator
+ *
+ * @internal
  */
-class TimeEfficientImplementationTest extends LongestCommonSubsequenceTest
+final class TimeEfficientImplementationTest extends LongestCommonSubsequenceTest
 {
     protected function createImplementation()
     {


### PR DESCRIPTION
Scoping down the classes helps keeping an easier BC promise and gives a clear signal to users what part of the package is intent to be API and what is tooling (like test) and should not be used.

(Next up will be the type hints, but I expect a lot of conflict on the current PR's so I hold on to that, after that one the line numbers can be done)