### PR TITLE
Add DifferOutputBuilderInterface.

### DIFF
--- a/src/Output/AbstractChunkOutputBuilder.php
+++ b/src/Output/AbstractChunkOutputBuilder.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/diff.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\Diff\Output;
+
+abstract class AbstractChunkOutputBuilder implements DiffOutputBuilderInterface
+{
+    /**
+     * Takes input of the diff array and returns the common parts.
+     * Iterates through diff line by line.
+     *
+     * @param array $diff
+     * @param int   $lineThreshold
+     *
+     * @return array
+     */
+    protected function getCommonChunks(array $diff, int $lineThreshold = 5): array
+    {
+        $diffSize     = \count($diff);
+        $capturing    = false;
+        $chunkStart   = 0;
+        $chunkSize    = 0;
+        $commonChunks = [];
+
+        for ($i = 0; $i < $diffSize; ++$i) {
+            if ($diff[$i][1] === 0 /* OLD */) {
+                if ($capturing === false) {
+                    $capturing  = true;
+                    $chunkStart = $i;
+                    $chunkSize  = 0;
+                } else {
+                    ++$chunkSize;
+                }
+            } elseif ($capturing !== false) {
+                if ($chunkSize >= $lineThreshold) {
+                    $commonChunks[$chunkStart] = $chunkStart + $chunkSize;
+                }
+
+                $capturing = false;
+            }
+        }
+
+        if ($capturing !== false && $chunkSize >= $lineThreshold) {
+            $commonChunks[$chunkStart] = $chunkStart + $chunkSize;
+        }
+
+        return $commonChunks;
+    }
+}

--- a/src/Output/DiffOnlyOutputBuilder.php
+++ b/src/Output/DiffOnlyOutputBuilder.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/diff.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Diff\Output;
+
+/**
+ * Builds a diff string representation in a loose unified diff format
+ * listing only changes lines. Does not include line numbers.
+ */
+final class DiffOnlyOutputBuilder implements DiffOutputBuilderInterface
+{
+    /**
+     * @var string
+     */
+    private $header;
+
+    public function __construct(string $header = "--- Original\n+++ New\n")
+    {
+        $this->header = $header;
+    }
+
+    public function getDiff(array $diff): string
+    {
+        $buffer = \fopen('php://memory', 'r+b');
+        \fwrite($buffer, $this->header);
+
+        foreach ($diff as $diffEntry) {
+            if ($diffEntry[1] === 1 /* ADDED */) {
+                \fwrite($buffer, '+' . $diffEntry[0] . "\n");
+            } elseif ($diffEntry[1] === 2 /* REMOVED */) {
+                \fwrite($buffer, '-' . $diffEntry[0] . "\n");
+            }
+        }
+
+        $diff = \stream_get_contents($buffer, -1, 0);
+        \fclose($buffer);
+
+        return $diff;
+    }
+}

--- a/src/Output/DiffOutputBuilderInterface.php
+++ b/src/Output/DiffOutputBuilderInterface.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/diff.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Diff\Output;
+
+/**
+ * Defines how an output builder should take a generated
+ * diff array and return a string representation of that diff.
+ */
+interface DiffOutputBuilderInterface
+{
+    public function getDiff(array $diff): string;
+}

--- a/src/Output/UnifiedDiffOutputBuilder.php
+++ b/src/Output/UnifiedDiffOutputBuilder.php
@@ -1,0 +1,97 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/diff.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\Diff\Output;
+
+/**
+ * Builds a diff string representation in unified diff format in chunks.
+ */
+final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
+{
+    /**
+     * @var string
+     */
+    private $header;
+
+    public function __construct(string $header = "--- Original\n+++ New\n")
+    {
+        $this->header = $header;
+    }
+
+    public function getDiff(array $diff): string
+    {
+        $old   = $this->getCommonChunks($diff, 5);
+        $start = isset($old[0]) ? $old[0] : 0;
+        $end   = \count($diff);
+
+        if (\count($old)) {
+            \end($old);
+            $tmp = \key($old);
+            \reset($old);
+            if ($old[$tmp] === $end - 1) {
+                $end = $tmp;
+            }
+        }
+
+        $buffer = $this->header;
+
+        if (!isset($old[$start])) {
+            $buffer = $this->getDiffBufferElementNew($diff, $buffer, $start);
+            ++$start;
+        }
+
+        for ($i = $start; $i < $end; $i++) {
+            if (isset($old[$i])) {
+                $i      = $old[$i];
+                $buffer = $this->getDiffBufferElementNew($diff, $buffer, $i);
+            } else {
+                $buffer = $this->getDiffBufferElement($diff, $buffer, $i);
+            }
+        }
+
+        return $buffer;
+    }
+
+    /**
+     * Gets individual buffer element with opening.
+     *
+     * @param array  $diff
+     * @param string $buffer
+     * @param int    $diffIndex
+     *
+     * @return string
+     */
+    private function getDiffBufferElementNew(array $diff, string $buffer, int $diffIndex): string
+    {
+        return $this->getDiffBufferElement($diff, $buffer . "@@ @@\n", $diffIndex);
+    }
+
+    /**
+     * Gets individual buffer element.
+     *
+     * @param array  $diff
+     * @param string $buffer
+     * @param int    $diffIndex
+     *
+     * @return string
+     */
+    private function getDiffBufferElement(array $diff, string $buffer, int $diffIndex): string
+    {
+        if ($diff[$diffIndex][1] === 1 /* ADDED */) {
+            $buffer .= '+' . $diff[$diffIndex][0] . "\n";
+        } elseif ($diff[$diffIndex][1] === 2 /* REMOVED */) {
+            $buffer .= '-' . $diff[$diffIndex][0] . "\n";
+        } else {
+            $buffer .= ' ' . $diff[$diffIndex][0] . "\n";
+        }
+
+        return $buffer;
+    }
+}


### PR DESCRIPTION
With the previous fixes and refactors this one is pretty clean (as it can be).
I've moved the logic around and with the exception of the `DiffOnlyOutputBuilder::getDiff` method no other changes are made.

This behaves the same
```php
new Differ;
```

The BC breaks:
```php
// case 1
// from
new Differ($header);
// to
new Differ(new UnifiedDiffOutputBuilder($header));

//case 2
// from
new Differ($header, true);
// to
new Differ(new DiffOnlyOutputBuilder($header));
```

Kindly note this PR does not introduce the line numbers yet. After agreement on this PR I'll follow up on that, keeping the PR's separate will keep everyone sane when reviewing and/or checking the history of the repo.

Thanks for considering!