### PR TITLE
Intro of WARNING (3), better header handling.

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -111,7 +111,7 @@ final class Differ
         if ($this->detectUnmatchedLineEndings($fromMatches, $toMatches)) {
             $diff[] = [
                 '#Warning: Strings contain different line endings!',
-                0
+                3
             ];
         }
 

--- a/src/Output/DiffOnlyOutputBuilder.php
+++ b/src/Output/DiffOnlyOutputBuilder.php
@@ -28,14 +28,22 @@ final class DiffOnlyOutputBuilder implements DiffOutputBuilderInterface
     public function getDiff(array $diff): string
     {
         $buffer = \fopen('php://memory', 'r+b');
-        \fwrite($buffer, $this->header);
+
+        if ('' !== $this->header) {
+            \fwrite($buffer, $this->header);
+            if ("\n" !== \substr($this->header, -1, 1)) {
+                \fwrite($buffer, "\n");
+            }
+        }
 
         foreach ($diff as $diffEntry) {
             if ($diffEntry[1] === 1 /* ADDED */) {
                 \fwrite($buffer, '+' . $diffEntry[0] . "\n");
             } elseif ($diffEntry[1] === 2 /* REMOVED */) {
                 \fwrite($buffer, '-' . $diffEntry[0] . "\n");
-            }
+            } elseif ($diffEntry[1] === 3 /* WARNING */) {
+                \fwrite($buffer, ' ' . $diffEntry[0] . "\n");
+            } // else { /* Not changed (old) 0 */
         }
 
         $diff = \stream_get_contents($buffer, -1, 0);

--- a/src/Output/UnifiedDiffOutputBuilder.php
+++ b/src/Output/UnifiedDiffOutputBuilder.php
@@ -40,7 +40,13 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
             }
         }
 
-        $buffer = $this->header;
+        $buffer = '';
+        if ('' !== $this->header) {
+            $buffer = $this->header;
+            if ("\n" !== \substr($this->header, -1, 1)) {
+                $buffer .= "\n";
+            }
+        }
 
         if (!isset($old[$start])) {
             $buffer = $this->getDiffBufferElementNew($diff, $buffer, $start);
@@ -88,7 +94,7 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
             $buffer .= '+' . $diff[$diffIndex][0] . "\n";
         } elseif ($diff[$diffIndex][1] === 2 /* REMOVED */) {
             $buffer .= '-' . $diff[$diffIndex][0] . "\n";
-        } else {
+        } else { /* Not changed (OLD) 0 or Warning 3 */
             $buffer .= ' ' . $diff[$diffIndex][0] . "\n";
         }
 


### PR DESCRIPTION
Little tree shaking for the line numbers PR.

This PR;

- introduces WARNING value (3) so the output knows if a diff entry is coming from the sources or is inserted as warning by the Differ (currently the warning is inserted as `old / not changed` entry)
- better header support such that the diff output always follows after the header and at least one line break
- the `diff lines only output` will now output the warnings raised by the Differ as well

Especially the `warning` value is needed to continue working on a unified diff compatible output builder.