### PR TITLE
Show Diff line endings

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -110,7 +110,7 @@ final class Differ
 
         if ($this->detectUnmatchedLineEndings($fromMatches, $toMatches)) {
             $diff[] = [
-                '#Warning: Strings contain different line endings!',
+                "#Warning: Strings contain different line endings!\n",
                 3
             ];
         }
@@ -175,7 +175,7 @@ final class Differ
      */
     private function splitStringByLines(string $input): array
     {
-        return \preg_split('(\r\n|\r|\n)', $input);
+        return \preg_split('/(.*\R)/', $input, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
     }
 
     /**

--- a/src/Output/DiffOnlyOutputBuilder.php
+++ b/src/Output/DiffOnlyOutputBuilder.php
@@ -38,12 +38,21 @@ final class DiffOnlyOutputBuilder implements DiffOutputBuilderInterface
 
         foreach ($diff as $diffEntry) {
             if ($diffEntry[1] === 1 /* ADDED */) {
-                \fwrite($buffer, '+' . $diffEntry[0] . "\n");
+                \fwrite($buffer, '+' . $diffEntry[0]);
             } elseif ($diffEntry[1] === 2 /* REMOVED */) {
-                \fwrite($buffer, '-' . $diffEntry[0] . "\n");
+                \fwrite($buffer, '-' . $diffEntry[0]);
             } elseif ($diffEntry[1] === 3 /* WARNING */) {
-                \fwrite($buffer, ' ' . $diffEntry[0] . "\n");
-            } // else { /* Not changed (old) 0 */
+                \fwrite($buffer, ' ' . $diffEntry[0]);
+
+                continue; // Warnings should not be tested for line break, it will always be there
+            } else { /* Not changed (old) 0 */
+                continue; // we didn't write the non changs line, so do not add a line break either
+            }
+
+            $lc = \substr($diffEntry[0], -1);
+            if ($lc !== "\n" && $lc !== "\r") {
+                \fwrite($buffer, "\n"); // \No newline at end of file
+            }
         }
 
         $diff = \stream_get_contents($buffer, -1, 0);

--- a/src/Output/UnifiedDiffOutputBuilder.php
+++ b/src/Output/UnifiedDiffOutputBuilder.php
@@ -100,11 +100,20 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
     private function writeDiffBufferElement(array $diff, $buffer, int $diffIndex)
     {
         if ($diff[$diffIndex][1] === 1 /* ADDED */) {
-            \fwrite($buffer, '+' . $diff[$diffIndex][0] . "\n");
+            \fwrite($buffer, '+' . $diff[$diffIndex][0]);
         } elseif ($diff[$diffIndex][1] === 2 /* REMOVED */) {
-            \fwrite($buffer, '-' . $diff[$diffIndex][0] . "\n");
-        } else { /* Not changed (OLD) 0 or Warning 3 */
-            \fwrite($buffer, ' ' . $diff[$diffIndex][0] . "\n");
+            \fwrite($buffer, '-' . $diff[$diffIndex][0]);
+        } elseif ($diff[$diffIndex][1] === 3 /* WARNING */) {
+            \fwrite($buffer, ' ' . $diff[$diffIndex][0]);
+
+            return; // Warnings should not be tested for line break, it will always be there
+        } else { /* OLD Not changed (0) */
+            \fwrite($buffer, ' ' . $diff[$diffIndex][0]);
+        }
+
+        $lc = \substr($diff[$diffIndex][0], -1);
+        if ($lc !== "\n" && $lc !== "\r") {
+            \fwrite($buffer, "\n"); // \No newline at end of file
         }
     }
 }

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -296,7 +296,25 @@ final class DifferTest extends TestCase
                 ],
                 "<?php\r\n",
                 "<?php\n",
-            ]
+            ],
+            'test line diff detection in array input' => [
+                [
+                    [
+                        "#Warning: Strings contain different line endings!\n",
+                        self::WARNING,
+                    ],
+                    [
+                        "<?php\r\n",
+                        self::REMOVED,
+                    ],
+                    [
+                        "<?php\n",
+                        self::ADDED,
+                    ],
+                ],
+                ["<?php\r\n"],
+                ["<?php\n"],
+            ],
         ];
     }
 
@@ -384,6 +402,11 @@ EOF
                 "--- Original\n+++ New\n@@ @@\n #Warning: Strings contain different line endings!\n-<?php\r\n+<?php\n A\n",
                 "<?php\r\nA\n",
                 "<?php\nA\n",
+            ],
+            [
+                "--- Original\n+++ New\n@@ @@\n #Warning: Strings contain different line endings!\n-a\r\n+\n+c\r",
+                "a\r\n",
+                "\nc\r",
             ],
         ];
     }
@@ -611,7 +634,7 @@ EOL;
         $this->assertSame($expected, $method->invoke($this->differ, $input));
     }
 
-    public function provideSplitStringByLinesCases()
+    public function provideSplitStringByLinesCases(): array
     {
         return [
             [


### PR DESCRIPTION
This PR:
- fixes diff. line endings detection; for example `\r\n` vs. `\r` is currently not picked up
- fixed diff. line endings detection when providing two arrays to `diffToArray`, currently detection is only done when two strings are provided
- differ appends the line break to the diff entries so the output can handle those

The last one is the most important one, not only for the output.
Sample code;
```php
    $diff = new \SebastianBergmann\Diff\Differ();
    $diff = $diff->diff(
        "<?php\n",
        "<?php\r"
    );
```

Output on 1.4
```bash
--- Original
+++ New
@@ @@
 #Warning: Strings contain different line endings!
 <?php
 
```

Output proposed in PR;
```bash
--- Original
+++ New
@@ @@
 #Warning: Strings contain different line endings!
-<?php
"<?php
```

(note the location of the last `"` because of the `\r` being outputted as well)
Having both a ADDED and REMOVED line is essential for creating valid diff, but already for readability in some other cases. 