### PR TITLE
POC add line numbers

### DIFF
--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -362,7 +362,7 @@ final class DifferTest extends TestCase
                 'abcde'
             ],
             [
-                "--- Original\n+++ New\n@@ @@\n-A\n+A1\n B\n",
+                "--- Original\n+++ New\n@@ @@\n-A\n+A1\n",
                 "A\nB",
                 "A1\nB",
             ],
@@ -375,10 +375,8 @@ final class DifferTest extends TestCase
 -b
 +p
 @@ @@
- i
 -j
 +w
- k
 
 EOF
             ,
@@ -399,7 +397,7 @@ EOF
                 "B\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1",
             ],
             [
-                "--- Original\n+++ New\n@@ @@\n #Warning: Strings contain different line endings!\n-<?php\r\n+<?php\n A\n",
+                "--- Original\n+++ New\n@@ @@\n #Warning: Strings contain different line endings!\n-<?php\r\n+<?php\n",
                 "<?php\r\nA\n",
                 "<?php\nA\n",
             ],
@@ -696,6 +694,314 @@ EOL;
                     'C'
                 ],
                 "\nA\r\nB\n\nC",
+            ],
+        ];
+    }
+
+    /**
+     * @param string $expected
+     * @param string $from
+     * @param string $to
+     * @dataProvider provideDiffWithLineNumbers
+     */
+    public function testDiffWithLineNumbers($expected, $from, $to)
+    {
+        $differ = new Differ(new UnifiedDiffOutputBuilder("--- Original\n+++ New\n", true));
+        $this->assertSame($expected, $differ->diff($from, $to));
+    }
+
+    public function provideDiffWithLineNumbers(): array
+    {
+        return [
+            'diff line 1 non_patch_compat' => [
+                '--- Original
++++ New
+@@ -1 +1 @@
+-AA
++BA
+',
+                'AA',
+                'BA',
+            ],
+            'diff line +1 non_patch_compat' => [
+                '--- Original
++++ New
+@@ -1 +1,2 @@
+-AZ
++
++B
+',
+                'AZ',
+                "\nB",
+            ],
+            'diff line -1 non_patch_compat' => [
+                '--- Original
++++ New
+@@ -1,2 +1 @@
+-
+-AF
++B
+',
+                "\nAF",
+                'B',
+            ],
+            'II non_patch_compat' => [
+                '--- Original
++++ New
+@@ -1,2 +1 @@
+-
+-
+'
+                ,
+                "\n\nA\n1",
+                "A\n1",
+            ],
+            'diff last line II - no trailing linebreak non_patch_compat' => [
+                '--- Original
++++ New
+@@ -8 +8 @@
+-E
++B
+',
+                "A\n\n\n\n\n\n\nE",
+                "A\n\n\n\n\n\n\nB",
+            ],
+            [
+                "--- Original\n+++ New\n@@ -1,2 +1 @@\n \n-\n",
+                "\n\n",
+                "\n",
+            ],
+            'diff line endings non_patch_compat' => [
+                "--- Original\n+++ New\n@@ -1 +1 @@\n #Warning: Strings contain different line endings!\n-<?php\r\n+<?php\n",
+                "<?php\r\n",
+                "<?php\n",
+            ],
+            'same non_patch_compat' => [
+                '--- Original
++++ New
+',
+                "AT\n",
+                "AT\n",
+            ],
+            [
+                '--- Original
++++ New
+@@ -1 +1 @@
+-b
++a
+',
+                "b\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n",
+                "a\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"
+            ],
+            'diff line @1' => [
+                '--- Original
++++ New
+@@ -1,2 +1,2 @@
+ ' . '
+-AG
++B
+',
+                "\nAG\n",
+                "\nB\n",
+            ],
+            'same multiple lines' => [
+                '--- Original
++++ New
+@@ -1,3 +1,3 @@
+ ' . '
+ ' . '
+-V
++B
+'
+
+                ,
+                "\n\nV\nC213",
+                "\n\nB\nC213",
+            ],
+            'diff last line I' => [
+                '--- Original
++++ New
+@@ -8 +8 @@
+-E
++B
+',
+                "A\n\n\n\n\n\n\nE\n",
+                "A\n\n\n\n\n\n\nB\n",
+            ],
+            'diff line middle' => [
+                '--- Original
++++ New
+@@ -8 +8 @@
+-X
++Z
+',
+                "A\n\n\n\n\n\n\nX\n\n\n\n\n\n\nAY",
+                "A\n\n\n\n\n\n\nZ\n\n\n\n\n\n\nAY",
+            ],
+            'diff last line III' => [
+                '--- Original
++++ New
+@@ -15 +15 @@
+-A
++B
+',
+                "A\n\n\n\n\n\n\nA\n\n\n\n\n\n\nA\n",
+                "A\n\n\n\n\n\n\nA\n\n\n\n\n\n\nB\n",
+            ],
+            [
+                '--- Original
++++ New
+@@ -1,7 +1,7 @@
+ A
+-B
++B1
+ D
+ E
+ EE
+ F
+-G
++G1
+',
+                "A\nB\nD\nE\nEE\nF\nG\nH",
+                "A\nB1\nD\nE\nEE\nF\nG1\nH",
+            ],
+            [
+                '--- Original
++++ New
+@@ -1 +1,2 @@
+ Z
++
+@@ -10 +11 @@
+-i
++x
+',
+                'Z
+a
+b
+c
+d
+e
+f
+g
+h
+i
+j',
+                'Z
+
+a
+b
+c
+d
+e
+f
+g
+h
+x
+j'
+            ],
+            [
+                '--- Original
++++ New
+@@ -1,5 +1,3 @@
+-
+-a
++b
+ A
+-a
+-
++b
+',
+                "\na\nA\na\n\n\nA",
+                "b\nA\nb\n\nA"
+            ],
+            [
+                <<<EOF
+--- Original
++++ New
+@@ -1,4 +1,2 @@
+-
+-
+ a
+-b
++p
+@@ -12 +10 @@
+-j
++w
+
+EOF
+                ,
+                "\n\na\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk",
+                "a\np\nc\nd\ne\nf\ng\nh\ni\nw\nk",
+            ],
+            [
+                '--- Original
++++ New
+@@ -11 +11 @@
+-A
++C
+',
+                "E\n\n\n\n\nB\n\n\n\n\nA\n\n\n\n\n\n\n\n\nD1",
+                "E\n\n\n\n\nB\n\n\n\n\nC\n\n\n\n\n\n\n\n\nD1",
+            ],
+            [
+                '--- Original
++++ New
+@@ -8 +8 @@
+-Z
++U
+@@ -15 +15 @@
+-X
++V
+@@ -22 +22 @@
+-Y
++W
+@@ -29 +29 @@
+-W
++X
+@@ -36 +36 @@
+-V
++Y
+@@ -43 +43 @@
+-U
++Z
+',
+                "\n\n\n\n\n\n\nZ\n\n\n\n\n\n\nX\n\n\n\n\n\n\nY\n\n\n\n\n\n\nW\n\n\n\n\n\n\nV\n\n\n\n\n\n\nU\n",
+                "\n\n\n\n\n\n\nU\n\n\n\n\n\n\nV\n\n\n\n\n\n\nW\n\n\n\n\n\n\nX\n\n\n\n\n\n\nY\n\n\n\n\n\n\nZ\n"
+            ],
+            [
+                <<<EOF
+--- Original
++++ New
+@@ -1,2 +1,2 @@
+ a
+-b
++p
+@@ -10 +10 @@
+-j
++w
+
+EOF
+            ,
+                "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk",
+                "a\np\nc\nd\ne\nf\ng\nh\ni\nw\nk",
+            ],
+            [
+                <<<EOF
+--- Original
++++ New
+@@ -1 +1 @@
+-A
++B
+
+EOF
+            ,
+                "A\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1",
+                "B\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1",
+            ],
+            [
+                "--- Original\n+++ New\n@@ -7 +7 @@\n-X\n+B\n",
+                "A\nA\nA\nA\nA\nA\nX\nC\nC\nC\nC\nC\nC",
+                "A\nA\nA\nA\nA\nA\nB\nC\nC\nC\nC\nC\nC",
             ],
         ];
     }

--- a/tests/DifferTestTest.php
+++ b/tests/DifferTestTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/diff.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\Diff;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @requires OS Linux
+ */
+final class DifferTestTest extends TestCase
+{
+    private $fileFrom;
+    private $filePatch;
+    private $fileTo;
+
+    protected function setUp()
+    {
+        $dir             = \realpath(__DIR__ . '/../') . '/';
+        $this->fileFrom  = $dir . 'from.txt';
+        $this->filePatch = $dir . 'patch.txt';
+    }
+
+    /**
+     * @dataProvider provideDiffWithLineNumbers
+     */
+    public function testTheTestProvideDiffWithLineNumbers($expected, $from, $to)
+    {
+        $this->runThisTest($expected, $from, $to);
+    }
+
+    public function provideDiffWithLineNumbers()
+    {
+        require_once __DIR__ . '/DifferTest.php';
+        $test  = new DifferTest();
+        $tests = $test->provideDiffWithLineNumbers();
+
+        $tests = \array_filter(
+            $tests,
+            function ($key) {
+                return !\is_string($key) || false === \strpos($key, 'non_patch_compat');
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
+        return $tests;
+    }
+
+    private function runThisTest(string $expected, string $from, string $to)
+    {
+        $expected = \str_replace('--- Original', '--- from.txt', $expected);
+        $expected = \str_replace('+++ New', '+++ from.txt', $expected);
+
+        @\unlink($this->fileFrom);
+        @\unlink($this->filePatch);
+
+        $this->assertNotFalse(\file_put_contents($this->fileFrom, $from));
+        $this->assertNotFalse(\file_put_contents($this->filePatch, $expected));
+
+        $command = \sprintf(
+            'patch -u --verbose %s < %s', // --posix
+            \escapeshellarg($this->fileFrom),
+            \escapeshellarg($this->filePatch)
+        );
+
+        \exec($command, $output, $d);
+
+        $this->assertSame(0, $d, \sprintf('%s | %s', $command, \implode("\n", $output)));
+
+        $patched = \file_get_contents($this->fileFrom);
+        $this->assertSame($patched, $to);
+
+        @\unlink($this->fileFrom);
+        @\unlink($this->filePatch);
+    }
+}


### PR DESCRIPTION
This PR introduces the line numbers to the `UnifiedDiffOutputBuilder` (finally ;) )

However there a few things to consider;
- the warning inserted about line break differences cause the output of the output builder to be _not_ compat with the `patch` tool
- the output builder does not add the `\No newline at end of file` to the output when a string has _not_ a line break as last character, making the output _not_ compat with the `patch` tool
- with above exceptions the output follows the unified diff format, like `patch -u` and can be consumed like `diff -u`
- the output is now minimal around the chunks, we might pick a better default;
  for example `diff` picks 3 lines above and below a changed line (` -u, -U NUM, --unified[=NUM]   output NUM (default 3) lines of unified context`)
- above might be a valuable option to be passed through the constructor to allow more tweaking

I left the incompats because;
- removing a feature that people might like (the warning) is not nice
- the  `\No newline at end of file` is only of value when diff'ing files, and not arbitrary strings as typically done by PHPUnit

I plan on writing a full compat version of the output builder so we can offer it 3rd party.

Let me know what you all think :)

ping @keradus @julienfalque please have a look if you've time

PS.
The last commit contains a test that is prop. best _not_ merged to the repo, but is very handy when debugging.