### PR TITLE
Fix zero range.

### DIFF
--- a/src/Output/UnifiedDiffOutputBuilder.php
+++ b/src/Output/UnifiedDiffOutputBuilder.php
@@ -114,12 +114,12 @@ final class UnifiedDiffOutputBuilder extends AbstractChunkOutputBuilder
         if ($this->addLineNumbers) {
             \fwrite($output, '@@ -' . (1 + $fromStart));
 
-            if ($fromRange > 1) {
+            if ($fromRange !== 1) {
                 \fwrite($output, ',' . $fromRange);
             }
 
             \fwrite($output, ' +' . (1 + $toStart));
-            if ($toRange > 1) {
+            if ($toRange !== 1) {
                 \fwrite($output, ',' . $toRange);
             }
 

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -748,7 +748,7 @@ EOL;
             'II non_patch_compat' => [
                 '--- Original
 +++ New
-@@ -1,2 +1 @@
+@@ -1,2 +1,0 @@
 -
 -
 '


### PR DESCRIPTION
I made a little mistake when rendering the ranges in hunks. The number of effected lines may be omitted when the range is exactly one, not when zero as it would change the meaning of the range.