### PR TITLE
Fix array diff'ing

### DIFF
--- a/src/Differ.php
+++ b/src/Differ.php
@@ -61,8 +61,8 @@ final class Differ
      */
     public function diff($from, $to, LongestCommonSubsequenceCalculator $lcs = null): string
     {
-        $from = $this->validateDiffInput($from);
-        $to   = $this->validateDiffInput($to);
+        $from = $this->normalizeDiffInput($from);
+        $to   = $this->normalizeDiffInput($to);
         $diff = $this->diffToArray($from, $to, $lcs);
 
         return $this->outputBuilder->getDiff($diff);
@@ -73,9 +73,9 @@ final class Differ
      *
      * @param mixed $input
      *
-     * @return string
+     * @return string|array
      */
-    private function validateDiffInput($input): string
+    private function normalizeDiffInput($input)
     {
         if (!\is_array($input) && !\is_string($input)) {
             return (string) $input;

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -89,6 +89,19 @@ final class DifferTest extends TestCase
         );
     }
 
+    public function testArrayDiffs()
+    {
+        $this->assertSame(
+            '--- Original
++++ New
+@@ @@
+-one
++two
+',
+            $this->differ->diff(array('one'), array('two'))
+        );
+    }
+
     public function arrayProvider(): array
     {
         return [


### PR DESCRIPTION
On `diff 1.4` :

```php
<?php
require_once __DIR__.'/vendor/autoload.php';

$a = new \SebastianBergmann\Diff\Differ();
$diff = $a->diff(array('one'), array('two'));
var_dump($diff);

die;
?>

[09:19 AM]-[possum@zoo1]-[/home/possum/work/diff]-[git 1.4]
$ php test.php
string(37) "--- Original
+++ New
@@ @@
-one
+two
"
```
 
However on `master`
```
$ php test.php 
PHP Fatal error:  Uncaught TypeError: Return value of SebastianBergmann\Diff\Differ::validateDiffInput() must be of the type string, array returned in /home/possum/work/diff/src/Differ.php:83
Stack trace:
#0 /home/possum/work/diff/src/Differ.php(63): SebastianBergmann\Diff\Differ->validateDiffInput(Array)
#1 /home/possum/work/diff/test.php(5): SebastianBergmann\Diff\Differ->diff(Array, Array)
#2 {main}
  thrown in /home/possum/work/diff/src/Differ.php on line 83
```

This PR fixes the code back to original behavior.

closes https://github.com/sebastianbergmann/diff/issues/70

(depends on https://github.com/sebastianbergmann/diff/pull/73)