### PR TITLE
Fix tests to work with SF5 process package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5 || ^8.0",
-        "symfony/process": "^2 || ^3.3 || ^4 || ^5"
+        "symfony/process": "^4 || ^5"
     },
     "autoload": {
         "classmap": [

--- a/tests/DifferTest.php
+++ b/tests/DifferTest.php
@@ -11,7 +11,6 @@
 namespace SebastianBergmann\Diff;
 
 use PHPUnit\Framework\TestCase;
-use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 
 /**
  * @covers SebastianBergmann\Diff\Differ

--- a/tests/Output/Integration/StrictUnifiedDiffOutputBuilderIntegrationTest.php
+++ b/tests/Output/Integration/StrictUnifiedDiffOutputBuilderIntegrationTest.php
@@ -203,7 +203,7 @@ final class StrictUnifiedDiffOutputBuilderIntegrationTest extends TestCase
             null,
             [
                 'from' => $this->fileFrom,
-                'to' => $this->fileTo,
+                'to'   => $this->fileTo,
             ]
         );
 
@@ -238,7 +238,7 @@ final class StrictUnifiedDiffOutputBuilderIntegrationTest extends TestCase
         $p->run(
             null,
             [
-                'dir' => $this->dir,
+                'dir'   => $this->dir,
                 'patch' => $this->filePatch,
             ]
         );
@@ -260,7 +260,7 @@ final class StrictUnifiedDiffOutputBuilderIntegrationTest extends TestCase
         $p->run(
             null,
             [
-                'from' => $this->fileFrom,
+                'from'  => $this->fileFrom,
                 'patch' => $this->filePatch,
             ]
         );

--- a/tests/Output/Integration/UnifiedDiffOutputBuilderIntegrationTest.php
+++ b/tests/Output/Integration/UnifiedDiffOutputBuilderIntegrationTest.php
@@ -95,7 +95,7 @@ final class UnifiedDiffOutputBuilderIntegrationTest extends TestCase
         $p->run(
             null,
             [
-                'from' => $this->fileFrom,
+                'from'  => $this->fileFrom,
                 'patch' => $this->filePatch,
             ]
         );
@@ -123,7 +123,7 @@ final class UnifiedDiffOutputBuilderIntegrationTest extends TestCase
         $p->run(
             null,
             [
-                'dir' => $this->dir,
+                'dir'   => $this->dir,
                 'patch' => $this->filePatch,
             ]
         );

--- a/tests/Output/Integration/UnifiedDiffOutputBuilderIntegrationTest.php
+++ b/tests/Output/Integration/UnifiedDiffOutputBuilderIntegrationTest.php
@@ -91,21 +91,21 @@ final class UnifiedDiffOutputBuilderIntegrationTest extends TestCase
         $this->assertNotFalse(\file_put_contents($this->fileFrom, $from));
         $this->assertNotFalse(\file_put_contents($this->filePatch, $diff));
 
-        $command = \sprintf(
-            'patch -u --verbose --posix  %s < %s', // --posix
-            \escapeshellarg($this->fileFrom),
-            \escapeshellarg($this->filePatch)
+        $p = Process::fromShellCommandline('patch -u --verbose --posix $from < $patch'); // --posix
+        $p->run(
+            null,
+            [
+                'from' => $this->fileFrom,
+                'patch' => $this->filePatch,
+            ]
         );
-
-        $p = new Process($command);
-        $p->run();
 
         $this->assertProcessSuccessful($p);
 
         $this->assertStringEqualsFile(
             $this->fileFrom,
             $to,
-            \sprintf('Patch command "%s".', $command)
+            \sprintf('Patch command "%s".', $p->getCommandLine())
         );
     }
 
@@ -119,14 +119,14 @@ final class UnifiedDiffOutputBuilderIntegrationTest extends TestCase
         $this->assertNotFalse(\file_put_contents($this->fileFrom, $from));
         $this->assertNotFalse(\file_put_contents($this->filePatch, $diff));
 
-        $command = \sprintf(
-            'git --git-dir %s apply --check -v --unsafe-paths --ignore-whitespace %s',
-            \escapeshellarg($this->dir),
-            \escapeshellarg($this->filePatch)
+        $p = Process::fromShellCommandline('git --git-dir $dir apply --check -v --unsafe-paths --ignore-whitespace $patch');
+        $p->run(
+            null,
+            [
+                'dir' => $this->dir,
+                'patch' => $this->filePatch,
+            ]
         );
-
-        $p = new Process($command);
-        $p->run();
 
         $this->assertProcessSuccessful($p);
     }

--- a/tests/Output/StrictUnifiedDiffOutputBuilderTest.php
+++ b/tests/Output/StrictUnifiedDiffOutputBuilderTest.php
@@ -275,7 +275,7 @@ final class StrictUnifiedDiffOutputBuilderTest extends TestCase
 
         $diff = $differ->diff("A\nB\n", "A\nX\n");
         $this->assertSame(
-'--- input.txt
+            '--- input.txt
 +++ output.txt
 @@ -1,2 +1,2 @@
  A

--- a/tests/Utils/UnifiedDiffAssertTraitIntegrationTest.php
+++ b/tests/Utils/UnifiedDiffAssertTraitIntegrationTest.php
@@ -48,8 +48,8 @@ final class UnifiedDiffAssertTraitIntegrationTest extends TestCase
         $p->run(
             null,
             [
-                'from' => \realpath($fileFrom),
-                'to' => \realpath($fileTo),
+                'from'  => \realpath($fileFrom),
+                'to'    => \realpath($fileTo),
                 'patch' => $this->filePatch,
             ]
         );

--- a/tests/Utils/UnifiedDiffAssertTraitIntegrationTest.php
+++ b/tests/Utils/UnifiedDiffAssertTraitIntegrationTest.php
@@ -44,15 +44,15 @@ final class UnifiedDiffAssertTraitIntegrationTest extends TestCase
      */
     public function testValidPatches(string $fileFrom, string $fileTo): void
     {
-        $command = \sprintf(
-            'diff -u %s %s > %s',
-            \escapeshellarg(\realpath($fileFrom)),
-            \escapeshellarg(\realpath($fileTo)),
-            \escapeshellarg($this->filePatch)
+        $p = Process::fromShellCommandline('diff -u $from $to > $patch');
+        $p->run(
+            null,
+            [
+                'from' => \realpath($fileFrom),
+                'to' => \realpath($fileTo),
+                'patch' => $this->filePatch,
+            ]
         );
-
-        $p = new Process($command);
-        $p->run();
 
         $exitCode = $p->getExitCode();
 
@@ -68,7 +68,7 @@ final class UnifiedDiffAssertTraitIntegrationTest extends TestCase
             $exitCode,
             \sprintf(
                 "Command exec. was not successful:\n\"%s\"\nOutput:\n\"%s\"\nStdErr:\n\"%s\"\nExit code %d.\n",
-                $command,
+                $p->getCommandLine(),
                 $p->getOutput(),
                 $p->getErrorOutput(),
                 $p->getExitCode()

--- a/tests/Utils/UnifiedDiffAssertTraitTest.php
+++ b/tests/Utils/UnifiedDiffAssertTraitTest.php
@@ -95,7 +95,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Date of header line does not match expected pattern, got "[invalid date]". Line 1.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-"--- Original\t[invalid date]
+            "--- Original\t[invalid date]
 +++ New
 @@ -1,2 +1,2 @@
 -A
@@ -111,7 +111,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote("Expected header line to start with \"+++  \", got \"+++INVALID\n\". Line 2.", '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++INVALID
 @@ -1,2 +1,2 @@
 -A
@@ -127,7 +127,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote("Expected line to start with '@', '-' or '+', got \"1\n\". Line 5.", '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8 +8 @@
 -Z
@@ -143,7 +143,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Expected string length of minimal 2, got 1. Line 4.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8 +8 @@
 
@@ -158,7 +158,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote("Hunk header line does not match expected pattern, got \"@@ INVALID -1,1 +1,1 @@\n\". Line 3.", '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ INVALID -1,1 +1,1 @@
 -Z
@@ -173,7 +173,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected new hunk; "from" (\'-\') start overlaps previous hunk. Line 6.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,1 +8,1 @@
 -Z
@@ -191,7 +191,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected new hunk; "to" (\'+\') start overlaps previous hunk. Line 6.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,1 +8,1 @@
 -Z
@@ -209,7 +209,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Expected hunk start (\'@\'), got "+". Line 6.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8 +8 @@
 -Z
@@ -225,7 +225,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected hunk start (\'@\'). Line 6.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,12 +8,12 @@
  ' . '
@@ -241,7 +241,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected line as 2 "No newline" markers have found, ". Line 8.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8 +8 @@
 -Z
@@ -259,7 +259,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected line as 2 "No newline" markers have found, ". Line 7.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8 +8 @@
 +U
@@ -276,7 +276,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected line as 2 "No newline" markers have found, ". Line 7.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8 +8 @@
 +U
@@ -293,7 +293,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected "\ No newline at end of file", it must be preceded by \'+\' or \'-\' line. Line 1.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'\ No newline at end of file
+            '\ No newline at end of file
 '
         );
     }
@@ -304,7 +304,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected "\\ No newline at end of file", "\\" was already closed. Line 8.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,12 +8,12 @@
  ' . '
@@ -322,7 +322,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Not expected from (\'-\'), already closed by "\ No newline at end of file". Line 6.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,12 +8,12 @@
 -A
@@ -390,7 +390,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected EOF, number of lines in hunk "from" (\'-\')) mismatched. Line 7.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,19 +7,2 @@
 -A
@@ -406,7 +406,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected EOF, number of lines in hunk "to" (\'+\')) mismatched. Line 7.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -8,2 +7,3 @@
 -A
@@ -422,7 +422,7 @@ final class UnifiedDiffAssertTraitTest extends TestCase
         $this->expectExceptionMessageRegExp(\sprintf('#^%s$#', \preg_quote('Unexpected EOF, number of lines in hunk "from" (\'-\')) and "to" (\'+\') mismatched. Line 7.', '#')));
 
         $this->assertValidUnifiedDiffFormat(
-'--- Original
+            '--- Original
 +++ New
 @@ -1,12 +1,14 @@
 -A


### PR DESCRIPTION
The PR fixes the tests because of the SF5 process API interface changes and updates the code style of some tests.
There are no functional changes to the package itself.

fixes: https://github.com/sebastianbergmann/diff/issues/90
replaces https://github.com/sebastianbergmann/diff/pull/89