### PR TITLE
Fix minimal Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",
-        "symfony/process": "^4 || ^5"
+        "symfony/process": "^4.2 || ^5"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
`fromShellCommandline` was introduced in 4.2