### PR TITLE
Update .gitignore export-ignore rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,9 @@
 /.github        export-ignore
 /.phive         export-ignore
-/.php_cs.dist   export-ignore
 /.psalm         export-ignore
+/.gitattributes export-ignore
+/.gitignore     export-ignore
+/.php_cs.dist   export-ignore
 /build.xml      export-ignore
 /phpunit.xml    export-ignore
 /tests          export-ignore


### PR DESCRIPTION
Adds `export-ignore` rules for `.gitattributes` file itself and `.gitignore` file. 

Thank you.