### PR TITLE
Allow spaces in parser

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -37,8 +37,8 @@ final class Parser
         $collected = [];
 
         for ($i = 0; $i < $lineCount; ++$i) {
-            if (preg_match('(^---\\s+(?P<file>\\S+))', $lines[$i], $fromMatch) &&
-                preg_match('(^\\+\\+\\+\\s+(?P<file>\\S+))', $lines[$i + 1], $toMatch)) {
+            if (preg_match('#^---\h+"?(?P<file>[^\\v\\t"]+)#', $lines[$i], $fromMatch) &&
+                preg_match('#^\\+\\+\\+\\h+"?(?P<file>[^\\v\\t"]+)#', $lines[$i + 1], $toMatch)) {
                 if ($diff !== null) {
                     $this->parseFileDiff($diff, $collected);
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -71,6 +71,49 @@ final class ParserTest extends TestCase
         $this->assertCount(4, $chunks[2]->getLines());
     }
 
+    public function testParseWithSpacesInFileNames(): void
+    {
+        $content =
+<<<PATCH
+diff --git a/Foo Bar.txt b/Foo Bar.txt
+index abcdefg..abcdefh 100644
+--- a/Foo Bar.txt
++++ b/Foo Bar.txt
+@@ -20,4 +20,5 @@ class Foo
+     const ONE = 1;
+     const TWO = 2;
++    const THREE = 3;
+     const FOUR = 4;
+
+PATCH;
+
+        $diffs = $this->parser->parse($content);
+
+        $this->assertEquals('a/Foo Bar.txt', $diffs[0]->getFrom());
+        $this->assertEquals('b/Foo Bar.txt', $diffs[0]->getTo());
+    }
+
+    public function testParseWithSpacesInFileNamesAndTimesamp(): void
+    {
+        $content =
+            <<<PATCH
+diff --git a/Foo Bar.txt b/Foo Bar.txt
+index abcdefg..abcdefh 100644
+--- "a/Foo Bar.txt"  2020-10-02 13:31:52.938811371 +0200
++++ "b/Foo Bar.txt"  2020-10-02 13:31:50.022792064 +0200
+@@ -20,4 +20,5 @@ class Foo
+     const ONE = 1;
+     const TWO = 2;
++    const THREE = 3;
+     const FOUR = 4;
+PATCH;
+
+        $diffs = $this->parser->parse($content);
+
+        $this->assertEquals('a/Foo Bar.txt', $diffs[0]->getFrom());
+        $this->assertEquals('b/Foo Bar.txt', $diffs[0]->getTo());
+    }
+
     public function testParseWithRemovedLines(): void
     {
         $content = <<<END


### PR DESCRIPTION
The from and to in diffs did not include the full path name when
spaces are being used. This change allows spaces in the file paths
as well (no tabs).