### PR TITLE
Fixed range parsing 

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -77,9 +77,9 @@ final class Parser
             if (preg_match('/^@@\s+-(?P<start>\d+)(?:,\s*(?P<startrange>\d+))?\s+\+(?P<end>\d+)(?:,\s*(?P<endrange>\d+))?\s+@@/', $line, $match)) {
                 $chunk = new Chunk(
                     (int) $match['start'],
-                    isset($match['startrange']) ? max(1, (int) $match['startrange']) : 1,
+                    isset($match['startrange']) ? max(0, (int) $match['startrange']) : 1,
                     (int) $match['end'],
-                    isset($match['endrange']) ? max(1, (int) $match['endrange']) : 1
+                    isset($match['endrange']) ? max(0, (int) $match['endrange']) : 1
                 );
 
                 $chunks[]  = $chunk;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -74,7 +74,7 @@ final class Parser
         $diffLines = [];
 
         foreach ($lines as $line) {
-            if (preg_match('/^@@\s+-(?P<start>\d+)(?:,\s*(?P<startrange>\d+))?\s+\+(?P<end>\d+)(?:,\s*(?P<endrange>\d+))?\s+@@/', $line, $match)) {
+            if (preg_match('/^@@\s+-(?P<start>\d+)(?:,\s*(?P<startrange>\d+))?\s+\+(?P<end>\d+)(?:,\s*(?P<endrange>\d+))?\s+@@/', $line, $match, PREG_UNMATCHED_AS_NULL)) {
                 $chunk = new Chunk(
                     (int) $match['start'],
                     isset($match['startrange']) ? max(0, (int) $match['startrange']) : 1,

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -193,6 +193,31 @@ END;
         $this->assertCount(1, $diff->getChunks());
     }
 
+    public function testParseWithRange(): void
+    {
+        $content = <<<'END'
+diff --git a/Test.txt b/Test.txt
+index abcdefg..abcdefh 100644
+--- a/Test.txt
++++ b/Test.txt
+@@ -49,0 +49,0 @@
+END;
+        $diffs = $this->parser->parse($content);
+        $this->assertContainsOnlyInstancesOf(Diff::class, $diffs);
+        $this->assertCount(1, $diffs);
+
+        $chunks = $diffs[0]->getChunks();
+
+        $this->assertContainsOnlyInstancesOf(Chunk::class, $chunks);
+        $this->assertCount(1, $chunks);
+
+        $chunk = $chunks[0];
+        $this->assertSame(49, $chunk->getStart());
+        $this->assertSame(49, $chunk->getEnd());
+        $this->assertSame(0, $chunk->getStartRange());
+        $this->assertSame(0, $chunk->getEndRange());
+    }
+
     /**
      * @psalm-param list<Diff> $expected
      */

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -201,6 +201,9 @@ index abcdefg..abcdefh 100644
 --- a/Test.txt
 +++ b/Test.txt
 @@ -49,0 +49,0 @@
+@@ -50 +50 @@
+ A
+-B
 END;
         $diffs = $this->parser->parse($content);
         $this->assertContainsOnlyInstancesOf(Diff::class, $diffs);
@@ -209,13 +212,19 @@ END;
         $chunks = $diffs[0]->getChunks();
 
         $this->assertContainsOnlyInstancesOf(Chunk::class, $chunks);
-        $this->assertCount(1, $chunks);
+        $this->assertCount(2, $chunks);
 
         $chunk = $chunks[0];
         $this->assertSame(49, $chunk->getStart());
         $this->assertSame(49, $chunk->getEnd());
         $this->assertSame(0, $chunk->getStartRange());
         $this->assertSame(0, $chunk->getEndRange());
+
+        $chunk = $chunks[1];
+        $this->assertSame(50, $chunk->getStart());
+        $this->assertSame(50, $chunk->getEnd());
+        $this->assertSame(1, $chunk->getStartRange());
+        $this->assertSame(1, $chunk->getEndRange());
     }
 
     /**


### PR DESCRIPTION
Fixes two errors when parsing diff files

1) the range can be zero, for example if lines are only deleted or added
2) `isset($match['startrange'])` is always `true`