### PR TITLE
Perf optimize MemoryEfficientLongestCommonSubsequenceCalculator

### DIFF
--- a/src/MemoryEfficientLongestCommonSubsequenceCalculator.php
+++ b/src/MemoryEfficientLongestCommonSubsequenceCalculator.php
@@ -78,7 +78,12 @@ final class MemoryEfficientLongestCommonSubsequenceCalculator implements Longest
                 if ($from[$i] === $to[$j]) {
                     $current[$j + 1] = $prev[$j] + 1;
                 } else {
-                    $current[$j + 1] = max($current[$j], $prev[$j + 1]);
+                    // don't use max() to avoid function call overhead
+                    if ($current[$j] > $prev[$j + 1]) {
+                        $current[$j + 1] = $current[$j];
+                    } else {
+                        $current[$j + 1] = $prev[$j + 1];
+                    }
                 }
             }
         }


### PR DESCRIPTION
when creating a diff of a file with 5000 lines we can see `MemoryEfficientLongestCommonSubsequenceCalculator` to bottleneck on `max()`. I think the main problem is the function call overhead, as its invoked ~43.000.000 times.

<img width="481" alt="grafik" src="https://user-images.githubusercontent.com/120441/235421093-895cd2e2-d58b-4245-8d97-0d0d0e6eb6a6.png">

with this change we just use plain php, which improves our workload in rector by 1 minute:

<img width="524" alt="grafik" src="https://user-images.githubusercontent.com/120441/235421208-e21d763e-8744-4544-a848-01ef24c6e39f.png">

refs https://github.com/rectorphp/rector/issues/7899
