### PR TITLE
Improve performance of TimeEfficientLongestCommonSubsequenceCalculator

### DIFF
--- a/src/TimeEfficientLongestCommonSubsequenceCalculator.php
+++ b/src/TimeEfficientLongestCommonSubsequenceCalculator.php
@@ -37,12 +37,24 @@ final class TimeEfficientLongestCommonSubsequenceCalculator implements LongestCo
 
         for ($i = 1; $i <= $fromLength; $i++) {
             for ($j = 1; $j <= $toLength; $j++) {
-                $o          = ($j * $width) + $i;
-                $matrix[$o] = max(
-                    $matrix[$o - 1],
-                    $matrix[$o - $width],
-                    $from[$i - 1] === $to[$j - 1] ? $matrix[$o - $width - 1] + 1 : 0
-                );
+                $o = ($j * $width) + $i;
+
+                // don't use max() to avoid function call overhead
+                $firstOrLast = $from[$i - 1] === $to[$j - 1] ? $matrix[$o - $width - 1] + 1 : 0;
+
+                if ($matrix[$o - 1] > $matrix[$o - $width]) {
+                    if ($firstOrLast > $matrix[$o - 1]) {
+                        $matrix[$o] = $firstOrLast;
+                    } else {
+                        $matrix[$o] = $matrix[$o - 1];
+                    }
+                } else {
+                    if ($firstOrLast > $matrix[$o - $width]) {
+                        $matrix[$o] = $firstOrLast;
+                    } else {
+                        $matrix[$o] = $matrix[$o - $width];
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
after https://github.com/sebastianbergmann/diff/pull/118 I measured the same workload with `TimeEfficientLongestCommonSubsequenceCalculator`.

turns out it also bottlenecks on `max()`:

<img width="1093" alt="grafik" src="https://user-images.githubusercontent.com/120441/235423084-b0f0f83a-1036-4503-8330-924a476a1c9a.png">

before this PR `TimeEfficientLongestCommonSubsequenceCalculator` is even slower then `MemoryEfficientLongestCommonSubsequenceCalculator` in this workload.

using the same approach we can see solid performance improvement with this PR and `TimeEfficientLongestCommonSubsequenceCalculator` is similar fast as `MemoryEfficientLongestCommonSubsequenceCalculator` but using way more memory:

<img width="835" alt="grafik" src="https://user-images.githubusercontent.com/120441/235423787-037130db-1827-4a8d-9805-b722b3349eae.png">
