### PR TITLE
Failing test for `new file mode` bug

### DIFF
--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -74,6 +74,25 @@ final class ParserTest extends TestCase
         $this->assertCount(4, $chunks[0]->lines());
     }
 
+    public function testParseNewFileMode(): void
+    {
+        $content = FileUtils::getFileContent(__DIR__ . '/fixtures/test.patch');
+
+        $diffs = $this->parser->parse($content);
+
+        foreach ($diffs as $diff) {
+            foreach ($diff->chunks() as $chunk) {
+                foreach ($chunk->lines() as $index => $line) {
+                    $content = $line->content();
+
+                    if (str_starts_with($content, 'new file mode')) {
+                        self::fail('Line #' . $index + 1 . ' in chunk ' . $chunk->start() . ' of diff ' . $diff->to() . ' is invalid');
+                    }
+                }
+            }
+        }
+    }
+
     public function testParseWithMultipleChunks(): void
     {
         $content = FileUtils::getFileContent(__DIR__ . '/fixtures/patch2.txt');

--- a/tests/fixtures/test.patch
+++ b/tests/fixtures/test.patch
@@ -1,0 +1,14 @@
+diff --git a/file1.txt b/file1.txt
+new file mode 100644
+--- /dev/null
++++ b/file1.txt
+@@ -0,0 +1,2 @@
++Line A
++Line B
+diff --git a/file2.txt b/file2.txt
+new file mode 100644
+--- /dev/null
++++ b/file2.txt
+@@ -0,0 +1,2 @@
++Line X
++Line Y


### PR DESCRIPTION
Also reproducible with real diffs in this repo, e.g.

```
git checkout 9aff9b4
git diff eb238060a950f2031ce51019f909b8ece35bccfb .github > tests/fixtures/test.patch
```