### PR TITLE
Fix parser dropping content lines that look like file headers

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -66,7 +66,7 @@ final class Parser
                 continue;
             }
 
-            if (preg_match('/^(?:diff --git |index [\da-f.]+|[+-]{3} [ab])/', $line) === 1) {
+            if (preg_match('/^(?:diff --git |index [\da-f.]+|(?:---|\+\+\+) [ab]\/)/', $line) === 1) {
                 continue;
             }
 

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -21,6 +21,8 @@ use function preg_split;
  */
 final class Parser
 {
+    private const string CHUNK_HEADER = '/^@@\s+-(?P<start>\d+)(?:,\s*(?P<startrange>\d+))?\s+\+(?P<end>\d+)(?:,\s*(?P<endrange>\d+))?\s+@@/';
+
     /**
      * @return list<Diff>
      */
@@ -36,10 +38,12 @@ final class Parser
             array_pop($lines);
         }
 
-        $lineCount = count($lines);
-        $diffs     = [];
-        $diff      = null;
-        $collected = [];
+        $lineCount     = count($lines);
+        $diffs         = [];
+        $diff          = null;
+        $collected     = [];
+        $fromLinesLeft = 0;
+        $toLinesLeft   = 0;
 
         for ($i = 0; $i < $lineCount; $i++) {
             if (!isset($lines[$i])) {
@@ -48,6 +52,37 @@ final class Parser
 
             $line     = $lines[$i];
             $nextLine = $lines[$i + 1] ?? null;
+
+            if ($fromLinesLeft > 0 || $toLinesLeft > 0) {
+                $marker = $line === '' ? ' ' : $line[0];
+
+                if ($marker === ' ' || $marker === '+' || $marker === '-' || $marker === '\\') {
+                    $collected[] = $line;
+
+                    if ($marker !== '+' && $marker !== '\\') {
+                        $fromLinesLeft--;
+                    }
+
+                    if ($marker !== '-' && $marker !== '\\') {
+                        $toLinesLeft--;
+                    }
+
+                    continue;
+                }
+
+                // malformed chunk: resynchronize on headers
+                $fromLinesLeft = 0;
+                $toLinesLeft   = 0;
+            }
+
+            if (preg_match(self::CHUNK_HEADER, $line, $chunkMatch, PREG_UNMATCHED_AS_NULL) === 1) {
+                $fromLinesLeft = isset($chunkMatch['startrange']) ? max(0, (int) $chunkMatch['startrange']) : 1;
+                $toLinesLeft   = isset($chunkMatch['endrange']) ? max(0, (int) $chunkMatch['endrange']) : 1;
+
+                $collected[] = $line;
+
+                continue;
+            }
 
             if ($nextLine !== null &&
                 preg_match('#^---\h+"?(?P<file>[^\\v\\t"]+)#', $line, $fromMatch) === 1 &&
@@ -92,7 +127,7 @@ final class Parser
         $diffLines = [];
 
         foreach ($lines as $line) {
-            if (preg_match('/^@@\s+-(?P<start>\d+)(?:,\s*(?P<startrange>\d+))?\s+\+(?P<end>\d+)(?:,\s*(?P<endrange>\d+))?\s+@@/', $line, $match, PREG_UNMATCHED_AS_NULL) === 1) {
+            if (preg_match(self::CHUNK_HEADER, $line, $match, PREG_UNMATCHED_AS_NULL) === 1) {
                 $chunk = new Chunk(
                     (int) $match['start'],
                     isset($match['startrange']) ? max(0, (int) $match['startrange']) : 1,

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\Diff;
 
+use function count;
 use function is_array;
 use function unserialize;
 use LogicException;
@@ -226,11 +227,15 @@ diff --git a/migration.sql b/migration.sql
 index abcdefg..abcdefh 100644
 --- a/migration.sql
 +++ b/migration.sql
-@@ -1,3 +1,4 @@
+@@ -1,5 +1,6 @@
  -- header comment
 +-- a comment added by this change
 +-- b comment added by this change
 -++ a stray marker removed
+--- a/foo gone
++++ b/foo added
+--- x removed
++++ y added
  SELECT 1;
 END;
         $diffs = $this->parser->parse($content);
@@ -243,27 +248,26 @@ END;
         $chunk = $chunks[0] ?? throw new LogicException('Expected one chunk.');
         $lines = $chunk->lines();
         $this->assertContainsOnlyInstancesOf(Line::class, $lines);
-        $this->assertCount(5, $lines);
 
-        $line = $lines[0] ?? throw new LogicException('Expected first line.');
-        $this->assertSame('-- header comment', $line->content());
-        $this->assertSame(Line::UNCHANGED, $line->type());
+        $expected = [
+            ['-- header comment', Line::UNCHANGED],
+            ['-- a comment added by this change', Line::ADDED],
+            ['-- b comment added by this change', Line::ADDED],
+            ['++ a stray marker removed', Line::REMOVED],
+            ['-- a/foo gone', Line::REMOVED],
+            ['++ b/foo added', Line::ADDED],
+            ['-- x removed', Line::REMOVED],
+            ['++ y added', Line::ADDED],
+            ['SELECT 1;', Line::UNCHANGED],
+        ];
 
-        $line = $lines[1] ?? throw new LogicException('Expected second line.');
-        $this->assertSame('-- a comment added by this change', $line->content());
-        $this->assertSame(Line::ADDED, $line->type());
+        $this->assertCount(count($expected), $lines);
 
-        $line = $lines[2] ?? throw new LogicException('Expected third line.');
-        $this->assertSame('-- b comment added by this change', $line->content());
-        $this->assertSame(Line::ADDED, $line->type());
-
-        $line = $lines[3] ?? throw new LogicException('Expected fourth line.');
-        $this->assertSame('++ a stray marker removed', $line->content());
-        $this->assertSame(Line::REMOVED, $line->type());
-
-        $line = $lines[4] ?? throw new LogicException('Expected fifth line.');
-        $this->assertSame('SELECT 1;', $line->content());
-        $this->assertSame(Line::UNCHANGED, $line->type());
+        foreach ($expected as $index => [$expectedContent, $expectedType]) {
+            $line = $lines[$index] ?? throw new LogicException('Expected line #' . $index . '.');
+            $this->assertSame($expectedContent, $line->content());
+            $this->assertSame($expectedType, $line->type());
+        }
     }
 
     public function testParseWithRange(): void

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -270,6 +270,49 @@ END;
         }
     }
 
+    public function testParseResynchronizesOnHeadersAfterMalformedChunk(): void
+    {
+        $content = <<<'END'
+diff --git a/first.txt b/first.txt
+index 1111111..2222222 100644
+--- a/first.txt
++++ b/first.txt
+@@ -1,3 +1,3 @@
+ shared
+-removed
++added
+diff --git a/second.txt b/second.txt
+index 3333333..4444444 100644
+--- a/second.txt
++++ b/second.txt
+@@ -1 +1 @@
+-old
++new
+END;
+        $diffs = $this->parser->parse($content);
+        $this->assertCount(2, $diffs);
+
+        $diff = $diffs[0] ?? throw new LogicException('Expected first diff.');
+        $this->assertSame('a/first.txt', $diff->from());
+        $this->assertSame('b/first.txt', $diff->to());
+
+        $chunks = $diff->chunks();
+        $this->assertCount(1, $chunks);
+
+        $chunk = $chunks[0] ?? throw new LogicException('Expected one chunk.');
+        $this->assertCount(3, $chunk->lines());
+
+        $diff = $diffs[1] ?? throw new LogicException('Expected second diff.');
+        $this->assertSame('a/second.txt', $diff->from());
+        $this->assertSame('b/second.txt', $diff->to());
+
+        $chunks = $diff->chunks();
+        $this->assertCount(1, $chunks);
+
+        $chunk = $chunks[0] ?? throw new LogicException('Expected one chunk.');
+        $this->assertCount(2, $chunk->lines());
+    }
+
     public function testParseWithRange(): void
     {
         $content = <<<'END'

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -236,27 +236,34 @@ END;
         $diffs = $this->parser->parse($content);
         $this->assertCount(1, $diffs);
 
-        $chunks = $diffs[0]->chunks();
+        $diff   = $diffs[0] ?? throw new LogicException('Expected one diff.');
+        $chunks = $diff->chunks();
         $this->assertCount(1, $chunks);
 
-        $lines = $chunks[0]->lines();
+        $chunk = $chunks[0] ?? throw new LogicException('Expected one chunk.');
+        $lines = $chunk->lines();
         $this->assertContainsOnlyInstancesOf(Line::class, $lines);
         $this->assertCount(5, $lines);
 
-        $this->assertSame('-- header comment', $lines[0]->content());
-        $this->assertSame(Line::UNCHANGED, $lines[0]->type());
+        $line = $lines[0] ?? throw new LogicException('Expected first line.');
+        $this->assertSame('-- header comment', $line->content());
+        $this->assertSame(Line::UNCHANGED, $line->type());
 
-        $this->assertSame('-- a comment added by this change', $lines[1]->content());
-        $this->assertSame(Line::ADDED, $lines[1]->type());
+        $line = $lines[1] ?? throw new LogicException('Expected second line.');
+        $this->assertSame('-- a comment added by this change', $line->content());
+        $this->assertSame(Line::ADDED, $line->type());
 
-        $this->assertSame('-- b comment added by this change', $lines[2]->content());
-        $this->assertSame(Line::ADDED, $lines[2]->type());
+        $line = $lines[2] ?? throw new LogicException('Expected third line.');
+        $this->assertSame('-- b comment added by this change', $line->content());
+        $this->assertSame(Line::ADDED, $line->type());
 
-        $this->assertSame('++ a stray marker removed', $lines[3]->content());
-        $this->assertSame(Line::REMOVED, $lines[3]->type());
+        $line = $lines[3] ?? throw new LogicException('Expected fourth line.');
+        $this->assertSame('++ a stray marker removed', $line->content());
+        $this->assertSame(Line::REMOVED, $line->type());
 
-        $this->assertSame('SELECT 1;', $lines[4]->content());
-        $this->assertSame(Line::UNCHANGED, $lines[4]->type());
+        $line = $lines[4] ?? throw new LogicException('Expected fifth line.');
+        $this->assertSame('SELECT 1;', $line->content());
+        $this->assertSame(Line::UNCHANGED, $line->type());
     }
 
     public function testParseWithRange(): void

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -219,6 +219,46 @@ END;
         $this->assertCount(1, $diff->chunks());
     }
 
+    public function testParseWithContentLinesResemblingHeaderLines(): void
+    {
+        $content = <<<'END'
+diff --git a/migration.sql b/migration.sql
+index abcdefg..abcdefh 100644
+--- a/migration.sql
++++ b/migration.sql
+@@ -1,3 +1,4 @@
+ -- header comment
++-- a comment added by this change
++-- b comment added by this change
+-++ a stray marker removed
+ SELECT 1;
+END;
+        $diffs = $this->parser->parse($content);
+        $this->assertCount(1, $diffs);
+
+        $chunks = $diffs[0]->chunks();
+        $this->assertCount(1, $chunks);
+
+        $lines = $chunks[0]->lines();
+        $this->assertContainsOnlyInstancesOf(Line::class, $lines);
+        $this->assertCount(5, $lines);
+
+        $this->assertSame('-- header comment', $lines[0]->content());
+        $this->assertSame(Line::UNCHANGED, $lines[0]->type());
+
+        $this->assertSame('-- a comment added by this change', $lines[1]->content());
+        $this->assertSame(Line::ADDED, $lines[1]->type());
+
+        $this->assertSame('-- b comment added by this change', $lines[2]->content());
+        $this->assertSame(Line::ADDED, $lines[2]->type());
+
+        $this->assertSame('++ a stray marker removed', $lines[3]->content());
+        $this->assertSame(Line::REMOVED, $lines[3]->type());
+
+        $this->assertSame('SELECT 1;', $lines[4]->content());
+        $this->assertSame(Line::UNCHANGED, $lines[4]->type());
+    }
+
     public function testParseWithRange(): void
     {
         $content = <<<'END'


### PR DESCRIPTION
The skip pattern `[+-]{3} [ab]` also matches ordinary hunk content, e.g. an added SQL comment:
```
    +-- some SQL comment
```
Such lines are silently dropped, so the **rest of the chunk shifts by one line**.

This restricts the pattern to real header shapes (`--- a/`, `+++ b/`) and adds a regression test.